### PR TITLE
fix: 의존성 설치 step 추가

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -35,6 +35,9 @@ jobs:
         with:
           node-version: "18.20.0"
 
+      - name: Install Dependencies
+        run: yarn install
+
       - name: Install git flow
         run: |
           sudo apt-get update


### PR DESCRIPTION
- github actions 환경에서 changeloog preset인 `conventional-changelog-conventionalcommits`를 찾지 못해 발생하는 문제를 해결하기 위해 해당 step 추가